### PR TITLE
Easily setup a custom global JVM trust store

### DIFF
--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -232,6 +232,20 @@ spec:
           value: {{ include "kafkaSchemaBasicAuth" . | quote }}
 
         # ssl/sasl
+        {{- if .Values.lenses.jvm.trustStoreFileData }}
+        - name: FILECONTENT_JVM_SSL_TRUSTSTORE
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . | quote }}
+              key:  "jvm.truststore.jks"
+        {{- end }}
+        {{- if .Values.lenses.jvm.trustStorePassword }}
+        - name: FILECONTENT_JVM_SSL_TRUSTSTORE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . | quote }}
+              key:  "jvm.truststore.password"
+        {{- end }}
         - name: LENSES_KAFKA_SETTINGS_SECURITY_PROTOCOL
           value: {{ include "securityProtocol" . | quote }}
         - name: LENSES_KAFKA_SETTINGS_SASL_MECHANISM

--- a/charts/lenses/templates/secrets.yaml
+++ b/charts/lenses/templates/secrets.yaml
@@ -10,6 +10,9 @@ metadata:
     lenses.io/app: "{{ include "fullname" . }}"
     lenses.io/app.type: lenses-secret
 data:
+  jvm.truststore.jks: |-
+{{ .Values.lenses.jvm.trustStoreFileData | default "" | indent 4 }}
+  jvm.truststore.password: {{ .Values.lenses.jvm.trustStorePassword | quote }}
   client.truststore.jks: |-
 {{ .Values.lenses.kafka.ssl.trustStoreFileData | default "" | indent 4 }}
   client.keystore.jks: |-

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -102,6 +102,11 @@ lenses:
     logBackOpts:
     #performanceOpts are any jvm tuning options to add to the jvm
     performanceOpts:
+    # base64 encoded truststore data
+    trustStoreFileData: |-
+
+    # trust store password
+    trustStorePassword:
 
   # broker details
   ## Brokers should be behind a service, if so set one entry in the hosts


### PR DESCRIPTION
Adding two new values to setup a global JVM trust store: 

- lenses.jvm.trustStoreFileData
- lenses.jvm.truststore.password