### PR TITLE
LENSES_OPTS truststore and keystore opts

### DIFF
--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -100,10 +100,6 @@ spec:
           {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}     
-        # command:
-        # - bash
-        # - -c
-        # - "sleep 10000000"
         env:
         - name: LENSES_OPTS
           value: ""

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               - key: lenses.keytab
                 path: lenses.keytab 
               - key: keytab
-                path: keytab                               
+                path: keytab
               - key: client.keystore.jks
                 path: client.keystore.jks
               - key: client.truststore.jks 
@@ -54,6 +54,10 @@ spec:
                 path: processor.keytab
               - key: registry.keytab
                 path: registry.keytab
+              - key: lenses.opts.keystore.jks
+                path: lenses.opts.keystore.jks
+              - key: lenses.opts.truststore.jks
+                path: lenses.opts.truststore.jks
         - name: krb
           configMap:
             name: {{ include "fullname" . | quote }}
@@ -96,14 +100,50 @@ spec:
           {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}     
+        # command:
+        # - bash
+        # - -c
+        # - "sleep 10000000"
         env:
+        - name: LENSES_OPTS
+          value: ""
+        {{- if .Values.lenses.opts.keyStoreFileData }}
+        - name: CLIENT_OPTS_KEYSTORE_FILE
+          value: "/mnt/secrets/lenses.opts.keystore.jks"
+        - name: LENSES_OPTS
+          value: "$(LENSES_OPTS) -Djavax.net.ssl.keyStore=$(CLIENT_OPTS_KEYSTORE_FILE)"
+        {{- end }}
+        {{- if .Values.lenses.opts.keyStorePassword }}
+        - name: CLIENT_OPTS_KEYSTORE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . | quote }}
+              key:  "lenses.opts.truststore.password"
+        - name: LENSES_OPTS
+          value: "$(LENSES_OPTS) -Djavax.net.ssl.keyStorePassword=$(CLIENT_OPTS_KEYSTORE_PASSWORD)"
+        {{- end }}
+        {{- if .Values.lenses.opts.trustStoreFileData }}
+        - name: CLIENT_OPTS_TRUSTSTORE_FILE
+          value: "/mnt/secrets/lenses.opts.truststore.jks"
+        - name: LENSES_OPTS
+          value: "$(LENSES_OPTS) -Djavax.net.ssl.trustStore=$(CLIENT_OPTS_TRUSTSTORE_FILE)"
+        {{- end }}
+        {{- if .Values.lenses.opts.trustStorePassword }}
+        - name: CLIENT_OPTS_TRUSTSTORE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . | quote }}
+              key:  "lenses.opts.truststore.password"
+        - name: LENSES_OPTS
+          value: "$(LENSES_OPTS) -Djavax.net.ssl.trustStorePassword=$(CLIENT_OPTS_TRUSTSTORE_PASSWORD)"
+        {{- end }}
         {{- if .Values.lenses.licenseUrl }} 
         - name: LICENSE_URL
           value: {{ .Values.lenses.licenseUrl }}
         {{- end }}
         {{- if .Values.lenses.kafka.sasl.enabled }}
         - name: LENSES_OPTS
-          value: "-Djava.security.krb5.conf=/etc/krb5.conf -Djava.security.auth.login.config=/mnt/secrets/jaas.conf"
+          value: "$(LENSES_OPTS) -Djava.security.krb5.conf=/etc/krb5.conf -Djava.security.auth.login.config=/mnt/secrets/jaas.conf"
         {{- end }}
         {{- if.Values.lenses.jvm.heapOpts}}
         - name: LENSES_HEAP_OPTS

--- a/charts/lenses/templates/secrets.yaml
+++ b/charts/lenses/templates/secrets.yaml
@@ -10,6 +10,12 @@ metadata:
     lenses.io/app: "{{ include "fullname" . }}"
     lenses.io/app.type: lenses-secret
 data:
+  lenses.opts.keystore.jks: |-
+{{ .Values.lenses.opts.keyStoreFileData | default "" | indent 4 }}
+  lenses.opts.keystore.password: {{ .Values.lenses.opts.keyStorePassword | default "" | quote }}
+  lenses.opts.truststore.jks: |-
+{{ .Values.lenses.opts.trustStoreFileData | default "" | indent 4 }}
+  lenses.opts.truststore.password: {{ .Values.lenses.opts.trustStorePassword | default "" | quote }}
   jvm.truststore.jks: |-
 {{ .Values.lenses.jvm.trustStoreFileData | default "" | indent 4 }}
   jvm.truststore.password: {{ .Values.lenses.jvm.trustStorePassword | default "" | quote }}

--- a/charts/lenses/templates/secrets.yaml
+++ b/charts/lenses/templates/secrets.yaml
@@ -16,8 +16,6 @@ data:
   lenses.opts.truststore.jks: |-
 {{ .Values.lenses.opts.trustStoreFileData | default "" | indent 4 }}
   lenses.opts.truststore.password: {{ .Values.lenses.opts.trustStorePassword | default "" | quote }}
-  jvm.truststore.jks: |-
-{{ .Values.lenses.jvm.trustStoreFileData | default "" | indent 4 }}
   jvm.truststore.password: {{ .Values.lenses.jvm.trustStorePassword | default "" | quote }}
   client.truststore.jks: |-
 {{ .Values.lenses.kafka.ssl.trustStoreFileData | default "" | indent 4 }}
@@ -54,4 +52,6 @@ stringData:
   processor.client.keystore.password: {{ .Values.lenses.sql.ssl.keyStorePassword | default "" | quote }}
   processor.client.truststore.password: {{ .Values.lenses.sql.ssl.trustStorePassword | default "" | quote }}
   schema.registry.password: {{ .Values.lenses.schemaRegistries.security.password | default "" | quote }}
+  jvm.truststore.jks: |-
+{{ .Values.lenses.jvm.trustStoreFileData | default "" | indent 4 }}
 

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -108,6 +108,19 @@ lenses:
     # trust store password
     trustStorePassword:
 
+  opts:
+    # base64 encoded truststore data
+    trustStoreFileData: |-
+
+    # trust store password
+    trustStorePassword: |-
+
+    # base64 encoded truststore data
+    keyStoreFileData: |-
+
+    # keystore password
+    keyStorePassword: |-
+
   # broker details
   ## Brokers should be behind a service, if so set one entry in the hosts
   ## If your brokers are outside explicitly add them to the hosts. Note you only need one to bootstrap

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -112,13 +112,13 @@ lenses:
     # base64 encoded truststore data
     trustStoreFileData: |-
 
-    # trust store password
+    # base64 trust store password
     trustStorePassword: |-
 
     # base64 encoded truststore data
     keyStoreFileData: |-
 
-    # keystore password
+    # base64 keystore password
     keyStorePassword: |-
 
   # broker details

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -110,15 +110,19 @@ lenses:
 
   opts:
     # base64 encoded truststore data
+    # openssl base64 < kafka.truststore.jks | tr -d '\n'
     trustStoreFileData: |-
 
     # base64 trust store password
+    # echo "$password" | tr -d '\n' | base64
     trustStorePassword: |-
 
     # base64 encoded truststore data
+    # openssl base64 < kafka.truststore.jks | tr -d '\n'
     keyStoreFileData: |-
 
     # base64 keystore password
+    # echo "$password" | tr -d '\n' | base64
     keyStorePassword: |-
 
   # broker details


### PR DESCRIPTION
- Users can now load via helm client truststore and keystore in LENSES_OPTS
- LENSES_OPTS is appended based on other variables that were passed. Example: jaas files will not overwrite the variable
- Fix FILECONTENT_JVM_SSL_TRUSTSTORE double encoding 