### PR TITLE
[lenses] Support SAML configuration in helm chart

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 description: A chart for Lenses
 name: lenses
-version: 3.2.3
+version: 3.2.4
 appVersion: 3.2.3
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -445,6 +445,14 @@ lenses.security.ldap.plugin.memberof.key={{ .Values.lenses.security.ldap.plugin.
 lenses.security.ldap.plugin.group.extract.regex={{ .Values.lenses.security.ldap.plugin.groupExtractRegex | quote }}
 lenses.security.ldap.plugin.person.name.key={{ .Values.lenses.security.ldap.plugin.personNameKey | quote }}
 {{- end -}} 
+{{- if .Values.lenses.security.saml.enabled }}
+lenses.security.saml.base.url={{ .Values.lenses.security.saml.baseUrl | quote }}
+lenses.security.saml.idp.provider={{ .Values.lenses.security.saml.provider | quote }}
+lenses.security.saml.idp.metadata.file="/mnt/secrets/saml.idp.xml"
+lenses.security.saml.keystore.location="/mnt/secrets/saml.keystore.jks"
+lenses.security.saml.keystore.password={{ .Values.lenses.security.saml.keyStorePassword | quote }}
+lenses.security.saml.key.password={{ .Values.lenses.security.saml.keyPassword | quote }}
+{{- end }}
 {{- if .Values.lenses.security.kerberos.enabled -}}
 {{ include "kerberos" .}}
 {{- end -}}

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -58,6 +58,13 @@ spec:
                 path: lenses.opts.keystore.jks
               - key: lenses.opts.truststore.jks
                 path: lenses.opts.truststore.jks
+              # SAML Secrets
+              {{- if .Values.lenses.security.saml.enabled }}
+              - key: saml.keystore.jks
+                path: saml.keystore.jks
+              - key: saml.idp.xml
+                path: saml.idp.xml
+              {{- end }}
         - name: krb
           configMap:
             name: {{ include "fullname" . | quote }}

--- a/charts/lenses/templates/secrets.yaml
+++ b/charts/lenses/templates/secrets.yaml
@@ -33,6 +33,10 @@ data:
 {{ .Values.lenses.security.kerberos.keytabData | default "" | indent 4 }}
   registry.keytab: |-
 {{ .Values.lenses.schemaRegistries.security.kerberos.keytabData | default "" | indent 4 }}
+  saml.keystore.jks: |-
+{{ .Values.lenses.security.saml.keyStoreFileData | default "" | indent 4 }}
+  saml.idp.xml: |-
+{{ .Values.lenses.security.saml.metadataFileData | default "" | indent 4 }}
 stringData:
   connect.clusters: |-
 {{ include "connect" . | indent 4 }}

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -364,6 +364,39 @@ lenses:
         groupExtractRegex: ""
         personNameKey: ""
 
+    saml:
+      enabled: false
+      # The HTTPS URL of the Lenses deployment.
+      # This needs to match the Service Provider (SP) URL
+      # given to the Identity Provider (IdP)
+      # as it will be used as part of the SAML handshake protocol.
+      baseUrl:
+
+      # Provider type.
+      # Supported values:
+      # "azure"    - Microsoft Azure
+      # "okta"     - Okta
+      # "onelogin" - OneLogin
+      # "keycloak" - Keycloak
+      provider:
+
+      # XML File provided by the external Identity Provider.
+      # This is needed in order for Lenses SAML to understand how to communicate
+      # with the Idenity Provider.
+      # content of the XML file - base64 encoded
+      #  openssl base64 < idp.xml | tr -d '\n'
+      metadataFileData: |-
+
+      # base64 encoded keystore data to be used for SAML crypto.
+      #  openssl base64 < saml.jks | tr -d '\n'
+      keyStoreFileData: |-
+
+      # Password to for accessing the keystore.
+      keyStorePassword:
+
+      # Password to use for the SAML generated key within the keystore.
+      keyPassword:
+
 
   # license is the Lenses license
   license: |-


### PR DESCRIPTION
Added a new section in values under `lenses.security` which is called
saml and you can enable and pass the necessary values for your setup.

Issue: cloud-768