### PR TITLE
Add readinessProbe for lenses

### DIFF
--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -80,6 +80,12 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.restPort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.restPort }}
+          initialDelaySeconds: 90
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Hello,

Since lenses takes couple of minutes to start, I added readinessProbe to the corresponding helm chart, so that behavior is more consistent with other community helm charts.

The main benefit is when running helm install/upgrade with --atomic flag, the command returns only when lenses is has started.

I set up the initialDelaySeconds to 90. I tested it on a local setup with kafka/zookeeper/schema-registry inside k8s, where average startup time of lenses is 85s according to my tests.

IHMO this delay should be configurable, as well as the livenessProbe initialDelaySeconds, because on our lenses production instance I had to set it to 180s because for whatever reason it is slower to initialise.


